### PR TITLE
PIZ1: Order Creation Sizes

### DIFF
--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,11 @@ def get_size_by_id(_id: int):
     response = size if not error else {'error': error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+
+@size.route('/', methods=GET)
+def get_sizes():
+    size, error = SizeController.get_all()
+    response = size if not error else {'error': error}
+    status_code = 200 if size else 404 if not error else 400
+    return jsonify(response), status_code

--- a/app/test/services/test_size.py
+++ b/app/test/services/test_size.py
@@ -1,0 +1,40 @@
+import pytest
+
+from app.test.utils.functions import get_random_string, get_random_price
+
+
+def test_create_size_service(create_size):
+    size = create_size.json
+    pytest.assume(create_size.status.startswith('200'))
+    pytest.assume(size['_id'])
+    pytest.assume(size['name'])
+    pytest.assume(size['price'])
+
+
+def test_update_size_service(client, create_size, size_uri):
+    current_size = create_size.json
+    update_data = {**current_size, 'name': get_random_string(), 'price':
+        get_random_price(1, 5)}
+    response = client.put(size_uri, json=update_data)
+    pytest.assume(response.status.startswith('200'))
+    updated_size = response.json
+    for param, value in update_data.items():
+        pytest.assume(updated_size[param] == value)
+
+
+def test_get_size_by_id_service(client, create_size, size_uri):
+    current_size = create_size.json
+    response = client.get(f'{size_uri}id/{current_size["_id"]}')
+    pytest.assume(response.status.startswith('200'))
+    returned_size = response.json
+    for param, value in current_size.items():
+        pytest.assume(returned_size[param] == value)
+
+
+def test_get_sizes_service(client, create_sizes, size_uri):
+    response = client.get(size_uri)
+    pytest.assume(response.status.startswith('200'))
+    returned_sizes = {size['_id']: size for size in
+                   response.json}
+    for size in create_sizes:
+        pytest.assume(size['_id'] in returned_sizes)


### PR DESCRIPTION
#### 🤔 Why?

- An endpoint to get all sizes available is needed, without it, an order cannot be placed in the system

#### 🛠 What I changed:

- `app/test/services/test_size.py`: Create tests for size service.
- `app/services/size.py`: Create endpoint to get all sizes in db.
#### 🗃️ Jira Issues:

- https://trello.com/c/vmXFiqAX

#### 🚦 Functional Testing Results:

- **API**:
![image](https://user-images.githubusercontent.com/106348291/200361287-3f2c92ca-93f5-495c-bf69-a03c239bf838.png)
Test results. All tests in `app/test/services/test_ingredient.py` PASSED. 

- **UI**: 
![image](https://user-images.githubusercontent.com/106348291/200361716-b786484f-bf7f-4c8f-8f6b-be1674e1915f.png)
![image](https://user-images.githubusercontent.com/106348291/200361777-e578c3bf-e6b3-4d0a-8992-42f78a727667.png)
